### PR TITLE
Transform in a rust crate lib + github CI

### DIFF
--- a/.github/.protolint.yaml
+++ b/.github/.protolint.yaml
@@ -1,0 +1,5 @@
+lint:
+  rules:
+    no_default: true
+    add:
+      - SERVICE_NAMES_UPPER_CAMEL_CASE

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: "CI"
+on: [pull_request]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  proto-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Check protobuf files
+        uses: plexsystems/protolint-action@v0.7.0
+        with:
+          configDirectory: .github/
+          srcDirectory: src/
+
+  fmt:
+    name: Cargo rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - name: Enforce formatting
+        run: cargo fmt --check
+
+  clippy:
+    name: Cargo clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - name: Linting
+        run: cargo clippy -- -D warnings
+
+  build:
+    name: Cargo build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Build
+        run: cargo build --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: arduino/setup-protoc@v2 # install protoc
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
@@ -43,6 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: arduino/setup-protoc@v2 # install protoc
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Build

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/target
+/Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "paastech-proto"
+description = "Protobuf definitions for all paastech gRPC services."
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+tonic = "0.9"
+prost = "0.11"
+
+[build-dependencies]
+tonic-build = "0.9"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,5 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tonic_build::compile_protos("src/gitsprout.proto")?;
+
+    Ok(())
+}

--- a/src/gitsprout.proto
+++ b/src/gitsprout.proto
@@ -1,9 +1,12 @@
 syntax = "proto3";
 package gitsprout;
 
+/* GitSprout service to interact with with the
+ * internal git server. */
 service GitSprout {
     rpc CreateRepository (RepositoryRequest) returns (RepositoryResponse);
     rpc DeleteRepository (RepositoryRequest) returns (RepositoryRequest);
+
     rpc AddSshKey (SshKeyRequest) returns (SshKeyResponse);
     rpc RemoveSshKey (SshKeyRequest) returns (SshKeyRequest);
 }

--- a/src/gitsprout.proto
+++ b/src/gitsprout.proto
@@ -1,14 +1,9 @@
 syntax = "proto3";
 package gitsprout;
 
-/* GitSprout service to interact with with the
- * internal git server. */
 service GitSprout {
     rpc CreateRepository (RepositoryRequest) returns (RepositoryResponse);
     rpc DeleteRepository (RepositoryRequest) returns (RepositoryRequest);
-
-    rpc AddSshKey (SshKeyRequest) returns (SshKeyResponse);
-    rpc RemoveSshKey (SshKeyRequest) returns (SshKeyRequest);
 }
 
 message RepositoryRequest {
@@ -16,14 +11,5 @@ message RepositoryRequest {
 }
 
 message RepositoryResponse {
-    string message = 1;
-}
-
-message SshKeyRequest {
-    string ssh_key = 1;
-    string user_id = 2;
-}
-
-message SshKeyResponse {
     string message = 1;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod gitsprout {
+    tonic::include_proto!("gitsprout");
+}


### PR DESCRIPTION
## What does this PR do ?

Changes:

- Transform this repositoty in a rust crate
- Github CI with:
  - [protolint-action](https://github.com/plexsystems/protolint-action/tree/master): To lint the protobuf files
  - rustfmt + clippy
  - cargo build

### How should this be manually tested?

- Step 1: add the crate dependency in an another repo  
  ref: [Specifying dependencies from git repositories](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#specifying-dependencies-from-git-repositories)
- Step 2: test if the modules are imported
